### PR TITLE
Add version number to Bazelisk formula

### DIFF
--- a/Formula/bazelisk.rb
+++ b/Formula/bazelisk.rb
@@ -16,7 +16,8 @@ class Bazelisk < Formula
   desc 'Bazelisk is a user-friendly launcher for Bazel.'
   homepage 'https://github.com/philwo/bazelisk'
   url "https://github.com/philwo/bazelisk/releases/download/v0.0.1/bazelisk-darwin-amd64"
-    
+  version '0.0.2'
+  
   # To generate run:
   # curl -L -N -s https://github.com/philwo/bazelisk/releases/download/v0.0.1/bazelisk-darwin-amd64 | shasum -a 256
   # on MacOS


### PR DESCRIPTION
Apparently we need to set explicit version numbers in order to get "brew upgrade bazelisk" to work (https://github.com/bazelbuild/continuous-integration/issues/525).